### PR TITLE
Break once a working GOPATH has been found

### DIFF
--- a/cmd/slurp/slurp.go
+++ b/cmd/slurp/slurp.go
@@ -147,6 +147,7 @@ func generate() (string, string, error) {
 			continue // cwd is outside this gopath
 		}
 		gopathsrc = gopathsrcTest
+		break
 	}
 
 	if gopathsrc == "" {


### PR DESCRIPTION
My `GOPATH` is `/home/<user>/go:/usr/share/go/contrib`, and it was causing Slurp to break because it would try to create a directory under `/usr/home`. Adding in a break statement once gopathsrc is set fixes it.

Ideally, it would check each possible path for writable status too, but this fix is enough to get it working for me.